### PR TITLE
add ERC721 tokens support (register, deposit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Run test cases:
 truffle test test/parsecBridge.js 
 ```
 
+# Contracts/Libraries
+
+## Rinkeby
+
+PriorityQueue: `0xe359b45836e835dcd155950563423100d79e34ee`
+TxLib: `0xafe7f62a5d755ecfcb88a8fa2f488f57ba209287`
+ParsecBridge: always changes :)
+
+
 ## LICENSE
 
 Project source files are made available under the terms of the Mozilla Public License (MPLv2). See individual files for details.

--- a/contracts/IntrospectionUtil.sol
+++ b/contracts/IntrospectionUtil.sol
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017-present, Parsec Labs (parseclabs.org)
+ *
+ * This source code is licensed under the Mozilla Public License, version 2,
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+ 
+pragma solidity ^0.4.24;
+
+/*
+* Based on https://github.com/ethereum/EIPs/blob/master/EIPS/eip-165.md
+*/
+library IntrospectionUtil {
+
+    function isERC721(address _contract) internal view returns (bool) {
+        uint256 success;
+        uint256 result;
+        
+        (success, result) = tryCallGetApproved(_contract);
+        return (success == 1) && (result == 0);
+    }
+
+    function tryCallGetApproved(address _contract) internal constant returns (uint256 success, uint256 result) {
+        bytes4 selector = bytes4(keccak256("getApproved(uint256)"));
+
+        assembly {
+                let x := mload(0x40)               // Find empty storage location using "free memory pointer"
+                mstore(x, selector)                // Place signature at begining of empty storage
+                mstore(add(x, 0x04), 0xffffffff)   // Place first argument directly next to signature
+
+                success := staticcall(
+                                    30000,         // 30k gas
+                                    _contract,     // To addr
+                                    x,             // Inputs are stored at location x
+                                    0x20,          // Inputs are 32 bytes long
+                                    x,             // Store output over input (saves space)
+                                    0x20)          // Outputs are 32 bytes long
+
+                result := mload(x)                 // Load the result
+        }
+    }
+}

--- a/contracts/ParsecBridge.sol
+++ b/contracts/ParsecBridge.sol
@@ -11,8 +11,11 @@ pragma solidity ^0.4.24;
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/math/Math.sol";
+
+import "./TransferrableToken.sol";
 import "./PriorityQueue.sol";
 import "./TxLib.sol";
+import "./IntrospectionUtil.sol";
 
 contract ParsecBridge {
   using SafeMath for uint256;
@@ -43,8 +46,9 @@ contract ParsecBridge {
   bytes32 public tipHash; // hash of first period that has extended chain to some height
 
   mapping(uint16 => PriorityQueue.Token) public tokens;
-  mapping(address => bool) tokenColors;
-  uint16 public tokenCount = 0;
+  mapping(address => uint16) tokenColors;
+  uint16 public erc20TokenCount = 0;
+  uint16 public nftTokenCount = 0;
 
   struct Slot {
     uint32 eventCounter;
@@ -87,8 +91,7 @@ contract ParsecBridge {
     address owner;
   }
   mapping(bytes32 => Exit) public exits;
-
-
+  
   constructor(uint256 _epochLength, uint256 _maxReward, uint256 _parentBlockInterval, uint256 _exitDuration) public {
     // init genesis preiod
     Period memory genesisPeriod;
@@ -111,13 +114,23 @@ contract ParsecBridge {
     emit EpochLength(epochLength);
   }
 
-  function registerToken(ERC20 _token) public {
+  function tokenCount() public view returns (uint256) {
+    return erc20TokenCount + nftTokenCount;
+  }
+
+  function registerToken(TransferrableToken _token) public {
     require(_token != address(0));
-    require(!tokenColors[_token]);
+    require(!isRegisteredToken(_token));
+    uint16 color;
+    if (IntrospectionUtil.isERC721(_token)) {
+      color = 32769 + nftTokenCount; // NFT color namespace starts from 2^15 + 1
+      nftTokenCount += 1;
+    } else {
+      color = erc20TokenCount;
+      erc20TokenCount += 1;
+    }
     uint256[] memory arr = new uint256[](1);
-    tokenColors[_token] = true;
-    uint16 color = tokenCount;
-    tokenCount += 1;
+    tokenColors[_token] = color;
     tokens[color] = PriorityQueue.Token({
       addr: _token,
       heapList: arr,
@@ -226,7 +239,7 @@ contract ParsecBridge {
     // auction
     else {
       if (slot.newStake > 0) {
-        tokens[0].addr.transfer(slot.newOwner, slot.newStake);
+        ERC20(tokens[0].addr).transfer(slot.newOwner, slot.newStake);
       }
       tokens[0].addr.transferFrom(tx.origin, this, _value);
       slot.newOwner = tx.origin;
@@ -244,7 +257,7 @@ contract ParsecBridge {
     Slot storage slot = slots[_slotId];
     require(lastCompleteEpoch + 1 >= slot.activationEpoch);
     if (slot.stake > 0) {
-      tokens[0].addr.transfer(slot.owner, slot.stake);
+      ERC20(tokens[0].addr).transfer(slot.owner, slot.stake);
       emit ValidatorLeave(slot.signer, _slotId, slot.tendermint, lastCompleteEpoch + 1);
     }
     slot.owner = slot.newOwner;
@@ -302,8 +315,8 @@ contract ParsecBridge {
     periods[_root] = newPeriod;
 
     // distribute rewards
-    uint256 totalSupply = tokens[0].addr.totalSupply();
-    uint256 stakedSupply = tokens[0].addr.balanceOf(this);
+    uint256 totalSupply = ERC20(tokens[0].addr).totalSupply();
+    uint256 stakedSupply = ERC20(tokens[0].addr).balanceOf(this);
     uint256 reward = maxReward;
     if (stakedSupply >= totalSupply.div(2)) {
       // 4 x br x as x (ts - as)
@@ -380,7 +393,7 @@ contract ParsecBridge {
     // slash operator
     slash(p.slot, 10 * maxReward);
     // reward 1 block reward
-    tokens[0].addr.transfer(msg.sender, maxReward);
+    ERC20(tokens[0].addr).transfer(msg.sender, maxReward);
   }
 
   function reportDoubleSpend(bytes32[] _proof, bytes32[] _prevProof) public {
@@ -442,20 +455,25 @@ contract ParsecBridge {
     }
   }
 
-  /*
-   * Add funds
+  /** 
+   * @notice Add to the network `(_amountOrTokenId)` amount of a `(_color)` tokens 
+   * or `(_amountOrTokenId)` token id if `(_color)` is NFT. 
+   * @dev Token should be registered with the Bridge first.
+   * @param _owner Account to transfer tokens from
+   * @param _amountOrTokenId Amount (for ERC20) or token ID (for ERC721) to transfer 
+   * @param _color Color of the token to deposit
    */
-  function deposit(address _owner, uint256 _amount, uint16 _color) public {
-    require(_color < tokenCount);
-    tokens[_color].addr.transferFrom(_owner, this, _amount);
+  function deposit(address _owner, uint256 _amountOrTokenId, uint16 _color) public {
+    require(tokens[_color].addr != address(0));
+    tokens[_color].addr.transferFrom(_owner, this, _amountOrTokenId);
     depositCount++;
     deposits[depositCount] = Deposit({
       height: periods[tipHash].height,
       owner: _owner,
       color: _color,
-      amount: _amount
+      amount: _amountOrTokenId
     });
-    emit NewDeposit(depositCount, _owner, _color, _amount);
+    emit NewDeposit(depositCount, _owner, _color, _amountOrTokenId);
   }
 
   function startExit(bytes32[] _proof, uint256 _oindex) public {
@@ -513,7 +531,8 @@ contract ParsecBridge {
     while (exitable_at <= block.timestamp && tokens[currentExit.color].currentSize > 0) {
       currentExit = exits[utxoId];
       if (currentExit.owner != 0 || currentExit.amount != 0) { // exit was removed
-        tokens[currentExit.color].addr.transfer(currentExit.owner, currentExit.amount);
+        // replace with transferFrom?
+        ERC20(tokens[currentExit.color].addr).transfer(currentExit.owner, currentExit.amount);
       }
       tokens[currentExit.color].delMin();
       delete exits[utxoId].owner;
@@ -531,6 +550,12 @@ contract ParsecBridge {
     uint256 priority = tokens[_color].getMin();
     utxoId = bytes32(uint128(priority));
     exitable_at = priority >> 128;
+  }
+
+  // check that token is registered. 
+  // 0 means either "empty" or "color 0". So if 0, let's check that "color 0" is taken by same token
+  function isRegisteredToken(address _token) internal view returns (bool) {
+    return tokenColors[_token] != 0 || (erc20TokenCount > 0 && tokens[0].addr == _token);
   }
 
 }

--- a/contracts/PriorityQueue.sol
+++ b/contracts/PriorityQueue.sol
@@ -10,6 +10,7 @@ pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "./TransferrableToken.sol";
 
 /**
  * @title PriorityQueue
@@ -20,7 +21,7 @@ library PriorityQueue {
   using SafeMath for uint256;
 
   struct Token {
-    ERC20 addr;
+    TransferrableToken addr;
     uint256[] heapList;
     uint256 currentSize;
   }

--- a/contracts/TransferrableToken.sol
+++ b/contracts/TransferrableToken.sol
@@ -1,0 +1,15 @@
+
+/**
+ * Copyright (c) 2017-present, Parsec Labs (parseclabs.org)
+ *
+ * This source code is licensed under the Mozilla Public License, version 2,
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+pragma solidity ^0.4.24;
+
+import "openzeppelin-solidity/contracts/introspection/ERC165.sol";
+
+contract TransferrableToken is ERC165 {
+  function transferFrom(address _from, address _to, uint256 _valueOrTokenId) public;
+}

--- a/contracts/mocks/SpaceDustNFT.sol
+++ b/contracts/mocks/SpaceDustNFT.sol
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2017-present, Parsec Labs (parseclabs.org)
+ *
+ * This source code is licensed under the Mozilla Public License, version 2,
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+pragma solidity ^0.4.24;
+
+import "openzeppelin-solidity/contracts/token/ERC721/ERC721Token.sol";
+import "openzeppelin-solidity/contracts/access/Whitelist.sol";
+
+/**
+ * @title SpaceDustNFT
+ * @dev Simple ERC721 token mintable by whitelisted accounts
+ */
+contract SpaceDustNFT is ERC721Token, Whitelist {
+
+  constructor() public ERC721Token("SpaceDustNFT", "SDST") {
+    addAddressToWhitelist(msg.sender);
+  }
+
+  function mint(address _to, uint32 _size, bool _isGlowing, uint8 _color) public onlyIfWhitelisted(msg.sender) {
+    require(_size > 0);
+    uint256 nftId = now << 41 | _size << 9 | _color << 1 | (_isGlowing ? 1 : 0);
+    super._mint(_to, nftId);
+  }
+
+  function burn(uint256 _tokenId) public onlyIfWhitelisted(msg.sender) {
+    super._burn(ownerOf(_tokenId), _tokenId);
+  }
+}
+

--- a/test/parsecBridge.js
+++ b/test/parsecBridge.js
@@ -365,10 +365,9 @@ contract('Parsec', (accounts) => {
       it('should allow to deposit NFT tokens', async () => {
         const nftToken = await SpaceDustNFT.new();
         let receipt = await nftToken.mint(bob, 10, true, 2);
-        const tokenId = receipt.logs[0].args._tokenId.toNumber();
+        const tokenId = receipt.logs[0].args._tokenId;
         receipt = await parsec.registerToken(nftToken.address);
         const color = receipt.logs[0].args.color.toNumber();
-        // TODO: fixme
         await nftToken.approve(parsec.address, tokenId, { from: bob });
         await parsec.deposit(bob, tokenId, color, { from: bob }).should.be.fulfilled;
       });

--- a/test/parsecBridge.js
+++ b/test/parsecBridge.js
@@ -12,6 +12,7 @@ import chai from 'chai';
 const ParsecBridge = artifacts.require('./ParsecBridge.sol');
 const PriorityQueue = artifacts.require('./PriorityQueue.sol');
 const SimpleToken = artifacts.require('SimpleToken');
+const SpaceDustNFT = artifacts.require('SpaceDustNFT');
 
 const should = chai
   .use(require('chai-as-promised'))
@@ -552,16 +553,29 @@ contract('Parsec', (accounts) => {
       parsec = await deployBridge(token, 8);
     });
 
-    it('should register a new token', async () => {
+    it('should register a new ERC20 token', async () => {
       assert.equal((await parsec.tokens(0))[0], token.address);
-      assert.equal(await parsec.tokenCount(), 1);
+      assert.equal((await parsec.tokenCount()).toNumber(), 1);
 
       const anotherToken = await SimpleToken.new();
       const res = await parsec.registerToken(anotherToken.address);
       
       const expectedColor = 1;
-      assert.equal(await parsec.tokenCount(), 2);
+      assert.equal((await parsec.tokenCount()).toNumber(), 2);
       assert.equal((await parsec.tokens(expectedColor))[0], anotherToken.address);
+      assert.equal(res.logs[0].event, 'NewToken');
+      assert.equal(res.logs[0].args.color.toNumber(), expectedColor);
+    });
+
+    it('should register a new ERC721 token', async () => {
+      assert.equal((await parsec.tokenCount()).toNumber(), 2);
+
+      const nftToken = await SpaceDustNFT.new();
+      const res = await parsec.registerToken(nftToken.address);
+
+      const expectedColor = 2 ** 15 + 1; // NFT tokens namespace starts from 2^15 + 1
+      assert.equal((await parsec.tokenCount()).toNumber(), 3);
+      assert.equal((await parsec.tokens(expectedColor))[0], nftToken.address);
       assert.equal(res.logs[0].event, 'NewToken');
       assert.equal(res.logs[0].args.color.toNumber(), expectedColor);
     });


### PR DESCRIPTION
Using separate color namespace for ERC721: colors starting from 2^15 + 1.

Using naive introspection to check if the token is ERC721: if static call to `getApproved(uint256)` don't fail and returns 0, we consider the token is ERC721.

I've considered using awesome ERC165 for this check, but this will limit the scope of tokens we can support (not everyone implements ERC165).

- [x] check `deposit`. Add more tests if needed

#42 